### PR TITLE
private-names (main branch)

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1329,6 +1329,7 @@ namespace ts {
                 if (token() !== SyntaxKind.Identifier) {
                     node.originalKeywordKind = token();
                 }
+                node.isPrivateName = !!(scanner.getTokenFlags() & TokenFlags.PrivateName);
                 node.escapedText = escapeLeadingUnderscores(internIdentifier(scanner.getTokenValue()));
                 nextToken();
                 return finishNode(node);

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1723,6 +1723,24 @@ namespace ts {
                         error(Diagnostics.Invalid_character);
                         pos++;
                         return token = SyntaxKind.Unknown;
+                    case CharacterCodes.hash:
+                        pos++;
+                        if (
+                            languageVersion === ScriptTarget.ESNext
+                            && isIdentifierStart(ch = text.charCodeAt(pos), languageVersion)
+                        ) {
+                            tokenFlags |= TokenFlags.PrivateName;
+                            pos++;
+                            while (pos < end && isIdentifierPart(ch = text.charCodeAt(pos), languageVersion)) pos++;
+                            tokenValue = text.substring(tokenPos, pos);
+                            if (ch === CharacterCodes.backslash) {
+                                tokenValue += scanIdentifierParts();
+                            }
+                            return token = SyntaxKind.Identifier;
+                        }
+                        error(Diagnostics.Invalid_character);
+                        // no `pos++` because already advanced at beginning of this `case` statement
+                        return token = SyntaxKind.Unknown;
                     default:
                         if (isIdentifierStart(ch, languageVersion)) {
                             pos++;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -683,6 +683,7 @@ namespace ts {
          */
         escapedText: __String;
         originalKeywordKind?: SyntaxKind;                         // Original syntaxKind which get set so that we can report an error later
+        isPrivateName: boolean;                                   // is private name like `this.#foo`
         /*@internal*/ autoGenerateFlags?: GeneratedIdentifierFlags; // Specifies whether to auto-generate the text for an identifier.
         /*@internal*/ autoGenerateId?: number;                    // Ensures unique generated identifiers get unique names, but clones get the same name.
         isInJSDocNamespace?: boolean;                             // if the node is a member in a JSDoc namespace
@@ -1574,6 +1575,7 @@ namespace ts {
         BinarySpecifier = 1 << 7,   // e.g. `0b0110010000000000`
         OctalSpecifier = 1 << 8,    // e.g. `0o777`
         ContainsSeparator = 1 << 9, // e.g. `0b1100_0101`
+        PrivateName = 1 << 10,      // e.g. `#foo`
         BinaryOrOctalSpecifier = BinarySpecifier | OctalSpecifier,
         NumericLiteralFlags = Scientific | Octal | HexSpecifier | BinarySpecifier | OctalSpecifier | ContainsSeparator
     }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -347,6 +347,7 @@ namespace ts {
         public kind: SyntaxKind.Identifier;
         public escapedText: __String;
         public symbol: Symbol;
+        public isPrivateName: boolean;
         public autoGenerateFlags: GeneratedIdentifierFlags;
         _primaryExpressionBrand: any;
         _memberExpressionBrand: any;

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.arrayType1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.arrayType1.json
@@ -13,6 +13,7 @@
             "pos": 1,
             "end": 2,
             "flags": "JSDoc",
+            "isPrivateName": false,
             "escapedText": "a"
         }
     }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.arrayType2.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.arrayType2.json
@@ -18,6 +18,7 @@
                 "pos": 1,
                 "end": 2,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "a"
             }
         }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.arrayType3.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.arrayType3.json
@@ -28,6 +28,7 @@
                         "pos": 2,
                         "end": 3,
                         "flags": "JSDoc",
+                        "isPrivateName": false,
                         "escapedText": "a"
                     }
                 }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.functionTypeWithTrailingComma.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.functionTypeWithTrailingComma.json
@@ -19,6 +19,7 @@
                     "pos": 10,
                     "end": 11,
                     "flags": "JSDoc",
+                    "isPrivateName": false,
                     "escapedText": "a"
                 }
             }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.keyword1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.keyword1.json
@@ -9,6 +9,7 @@
         "end": 4,
         "flags": "JSDoc",
         "originalKeywordKind": "VarKeyword",
+        "isPrivateName": false,
         "escapedText": "var"
     }
 }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.methodInRecordType.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.methodInRecordType.json
@@ -14,6 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "foo"
             },
             "parameters": {

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.newType1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.newType1.json
@@ -15,6 +15,7 @@
                 "end": 13,
                 "flags": "JSDoc",
                 "originalKeywordKind": "NewKeyword",
+                "isPrivateName": false,
                 "escapedText": "new"
             },
             "type": {
@@ -32,6 +33,7 @@
                         "pos": 14,
                         "end": 15,
                         "flags": "JSDoc",
+                        "isPrivateName": false,
                         "escapedText": "a"
                     },
                     "right": {
@@ -39,6 +41,7 @@
                         "pos": 16,
                         "end": 17,
                         "flags": "JSDoc",
+                        "isPrivateName": false,
                         "escapedText": "b"
                     }
                 }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType2.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType2.json
@@ -14,6 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "foo"
             }
         },

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType3.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType3.json
@@ -14,6 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "foo"
             },
             "type": {

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType4.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType4.json
@@ -14,6 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "foo"
             }
         },
@@ -27,6 +28,7 @@
                 "pos": 6,
                 "end": 10,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "bar"
             }
         },

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType5.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType5.json
@@ -14,6 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "foo"
             },
             "type": {
@@ -33,6 +34,7 @@
                 "pos": 14,
                 "end": 18,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "bar"
             }
         },

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType6.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType6.json
@@ -14,6 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "foo"
             }
         },
@@ -27,6 +28,7 @@
                 "pos": 6,
                 "end": 10,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "bar"
             },
             "type": {

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType7.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType7.json
@@ -14,6 +14,7 @@
                 "pos": 2,
                 "end": 5,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "foo"
             },
             "type": {
@@ -33,6 +34,7 @@
                 "pos": 14,
                 "end": 18,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "bar"
             },
             "type": {

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType8.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.recordType8.json
@@ -15,6 +15,7 @@
                 "end": 10,
                 "flags": "JSDoc",
                 "originalKeywordKind": "FunctionKeyword",
+                "isPrivateName": false,
                 "escapedText": "function"
             }
         },

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.thisType1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.thisType1.json
@@ -15,6 +15,7 @@
                 "end": 14,
                 "flags": "JSDoc",
                 "originalKeywordKind": "ThisKeyword",
+                "isPrivateName": false,
                 "escapedText": "this"
             },
             "type": {
@@ -32,6 +33,7 @@
                         "pos": 15,
                         "end": 16,
                         "flags": "JSDoc",
+                        "isPrivateName": false,
                         "escapedText": "a"
                     },
                     "right": {
@@ -39,6 +41,7 @@
                         "pos": 17,
                         "end": 18,
                         "flags": "JSDoc",
+                        "isPrivateName": false,
                         "escapedText": "b"
                     }
                 }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.trailingCommaInRecordType.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.trailingCommaInRecordType.json
@@ -14,6 +14,7 @@
                 "pos": 2,
                 "end": 3,
                 "flags": "JSDoc",
+                "isPrivateName": false,
                 "escapedText": "a"
             }
         },

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeArgumentsNotFollowingDot.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeArgumentsNotFollowingDot.json
@@ -8,6 +8,7 @@
         "pos": 1,
         "end": 2,
         "flags": "JSDoc",
+        "isPrivateName": false,
         "escapedText": "a"
     },
     "typeArguments": {

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeOfType.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeOfType.json
@@ -8,6 +8,7 @@
         "pos": 7,
         "end": 9,
         "flags": "JSDoc",
+        "isPrivateName": false,
         "escapedText": "M"
     }
 }

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference1.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference1.json
@@ -8,6 +8,7 @@
         "pos": 1,
         "end": 2,
         "flags": "JSDoc",
+        "isPrivateName": false,
         "escapedText": "a",
         "jsdocDotPos": 2
     },

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference2.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference2.json
@@ -8,6 +8,7 @@
         "pos": 1,
         "end": 2,
         "flags": "JSDoc",
+        "isPrivateName": false,
         "escapedText": "a",
         "jsdocDotPos": 2
     },

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference3.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.typeReference3.json
@@ -13,6 +13,7 @@
             "pos": 1,
             "end": 2,
             "flags": "JSDoc",
+            "isPrivateName": false,
             "escapedText": "a"
         },
         "right": {
@@ -21,6 +22,7 @@
             "end": 11,
             "flags": "JSDoc",
             "originalKeywordKind": "FunctionKeyword",
+            "isPrivateName": false,
             "escapedText": "function"
         }
     }

--- a/tests/baselines/reference/MemberFunctionDeclaration8_es6.errors.txt
+++ b/tests/baselines/reference/MemberFunctionDeclaration8_es6.errors.txt
@@ -1,18 +1,21 @@
 tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration8_es6.ts(4,9): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration8_es6.ts(4,12): error TS1127: Invalid character.
+tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration8_es6.ts(4,12): error TS1109: Expression expected.
+tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration8_es6.ts(4,13): error TS1127: Invalid character.
 tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration8_es6.ts(4,14): error TS1109: Expression expected.
 tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration8_es6.ts(4,16): error TS2304: Cannot find name 'bar'.
 tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration8_es6.ts(5,12): error TS2304: Cannot find name 'bar'.
 
 
-==== tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration8_es6.ts (5 errors) ====
+==== tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration8_es6.ts (6 errors) ====
     class C {
       foo() {
         // Make sure we don't think of *bar as the start of a generator method.
         if (a) # * bar;
             ~
 !!! error TS2304: Cannot find name 'a'.
-               
+               ~
+!!! error TS1109: Expression expected.
+                
 !!! error TS1127: Invalid character.
                  ~
 !!! error TS1109: Expression expected.

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1056,6 +1056,7 @@ declare namespace ts {
          */
         escapedText: __String;
         originalKeywordKind?: SyntaxKind;
+        isPrivateName: boolean;
         autoGenerateFlags?: GeneratedIdentifierFlags;
         autoGenerateId?: number;
         isInJSDocNamespace?: boolean;
@@ -1573,6 +1574,7 @@ declare namespace ts {
         BinarySpecifier = 128,
         OctalSpecifier = 256,
         ContainsSeparator = 512,
+        PrivateName = 1024,
         BinaryOrOctalSpecifier = 384,
         NumericLiteralFlags = 1008
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -497,6 +497,7 @@ declare namespace ts {
          */
         escapedText: __String;
         originalKeywordKind?: SyntaxKind;
+        isPrivateName: boolean;
         isInJSDocNamespace?: boolean;
     }
     interface TransientIdentifier extends Identifier {

--- a/tests/baselines/reference/parseErrorInHeritageClause1.errors.txt
+++ b/tests/baselines/reference/parseErrorInHeritageClause1.errors.txt
@@ -1,11 +1,14 @@
 tests/cases/compiler/parseErrorInHeritageClause1.ts(1,17): error TS2304: Cannot find name 'A'.
-tests/cases/compiler/parseErrorInHeritageClause1.ts(1,19): error TS1127: Invalid character.
+tests/cases/compiler/parseErrorInHeritageClause1.ts(1,19): error TS1005: ',' expected.
+tests/cases/compiler/parseErrorInHeritageClause1.ts(1,20): error TS1127: Invalid character.
 
 
-==== tests/cases/compiler/parseErrorInHeritageClause1.ts (2 errors) ====
+==== tests/cases/compiler/parseErrorInHeritageClause1.ts (3 errors) ====
     class C extends A # {
                     ~
 !!! error TS2304: Cannot find name 'A'.
-                      
+                      ~
+!!! error TS1005: ',' expected.
+                       
 !!! error TS1127: Invalid character.
     }

--- a/tests/baselines/reference/parserErrorRecovery_Block2.errors.txt
+++ b/tests/baselines/reference/parserErrorRecovery_Block2.errors.txt
@@ -1,10 +1,13 @@
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/Blocks/parserErrorRecovery_Block2.ts(2,5): error TS1127: Invalid character.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/Blocks/parserErrorRecovery_Block2.ts(2,5): error TS1128: Declaration or statement expected.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/Blocks/parserErrorRecovery_Block2.ts(2,6): error TS1127: Invalid character.
 
 
-==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/Blocks/parserErrorRecovery_Block2.ts (1 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/Blocks/parserErrorRecovery_Block2.ts (2 errors) ====
     function f() {
         #
-        
+        ~
+!!! error TS1128: Declaration or statement expected.
+         
 !!! error TS1127: Invalid character.
         return;
     }

--- a/tests/baselines/reference/parserErrorRecovery_ClassElement3.errors.txt
+++ b/tests/baselines/reference/parserErrorRecovery_ClassElement3.errors.txt
@@ -1,13 +1,17 @@
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts(2,4): error TS1127: Invalid character.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts(2,4): error TS1128: Declaration or statement expected.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts(2,5): error TS1127: Invalid character.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts(6,4): error TS1109: Expression expected.
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts(7,4): error TS1127: Invalid character.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts(7,4): error TS1132: Enum member expected.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts(7,5): error TS1005: '}' expected.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts(7,5): error TS1127: Invalid character.
 
 
-==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts (4 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts (6 errors) ====
     module M {
        #
-       
+       ~
+!!! error TS1128: Declaration or statement expected.
+        
 !!! error TS1127: Invalid character.
        class C {
        }
@@ -16,7 +20,9 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErr
        ~~~~
 !!! error TS1109: Expression expected.
        #
-       
-!!! error TS1127: Invalid character.
+       ~
+!!! error TS1132: Enum member expected.
         
 !!! error TS1005: '}' expected.
+        
+!!! error TS1127: Invalid character.

--- a/tests/baselines/reference/parserErrorRecovery_ParameterList4.errors.txt
+++ b/tests/baselines/reference/parserErrorRecovery_ParameterList4.errors.txt
@@ -1,8 +1,11 @@
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ParameterLists/parserErrorRecovery_ParameterList4.ts(1,14): error TS1127: Invalid character.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ParameterLists/parserErrorRecovery_ParameterList4.ts(1,14): error TS1138: Parameter declaration expected.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ParameterLists/parserErrorRecovery_ParameterList4.ts(1,15): error TS1127: Invalid character.
 
 
-==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ParameterLists/parserErrorRecovery_ParameterList4.ts (1 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ParameterLists/parserErrorRecovery_ParameterList4.ts (2 errors) ====
     function f(a,#) {
-                 
+                 ~
+!!! error TS1138: Parameter declaration expected.
+                  
 !!! error TS1127: Invalid character.
     }

--- a/tests/baselines/reference/parserSkippedTokens16.errors.txt
+++ b/tests/baselines/reference/parserSkippedTokens16.errors.txt
@@ -2,13 +2,14 @@ tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.t
 tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.ts(1,6): error TS1005: ';' expected.
 tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.ts(1,8): error TS2304: Cannot find name 'Bar'.
 tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.ts(1,12): error TS1005: ';' expected.
-tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.ts(2,22): error TS1127: Invalid character.
+tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.ts(2,22): error TS1144: '{' or ';' expected.
+tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.ts(2,23): error TS1127: Invalid character.
 tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.ts(3,3): error TS1109: Expression expected.
 tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.ts(6,5): error TS1138: Parameter declaration expected.
 tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.ts(8,14): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.ts (8 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.ts (9 errors) ====
     foo(): Bar { }
     ~~~
 !!! error TS2552: Cannot find name 'foo'. Did you mean 'Foo'?
@@ -19,7 +20,9 @@ tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens16.t
                ~
 !!! error TS1005: ';' expected.
     function Foo      () #   { }
-                         
+                         ~
+!!! error TS1144: '{' or ';' expected.
+                          
 !!! error TS1127: Invalid character.
     4+:5
       ~

--- a/tests/baselines/reference/shebangError.errors.txt
+++ b/tests/baselines/reference/shebangError.errors.txt
@@ -1,14 +1,17 @@
-tests/cases/compiler/shebangError.ts(2,1): error TS1127: Invalid character.
+tests/cases/compiler/shebangError.ts(2,1): error TS1128: Declaration or statement expected.
+tests/cases/compiler/shebangError.ts(2,2): error TS1127: Invalid character.
 tests/cases/compiler/shebangError.ts(2,2): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/compiler/shebangError.ts(2,12): error TS2304: Cannot find name 'env'.
 tests/cases/compiler/shebangError.ts(2,16): error TS1005: ';' expected.
 tests/cases/compiler/shebangError.ts(2,16): error TS2304: Cannot find name 'node'.
 
 
-==== tests/cases/compiler/shebangError.ts (5 errors) ====
+==== tests/cases/compiler/shebangError.ts (6 errors) ====
     var foo = 'Shebang is only allowed on the first line';
     #!/usr/bin/env node
-    
+    ~
+!!! error TS1128: Declaration or statement expected.
+     
 !!! error TS1127: Invalid character.
      ~~~~~~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.


### PR DESCRIPTION
Do the bare minimium to
get private names to parse.

Added `isPrivateName` flag to
`Identifier` interface.

Just accept all the baseline changes.

TODO: parse for real, and fix baselines
for real.